### PR TITLE
Fix unwanted behavior when using attrForSelected

### DIFF
--- a/iron-auto-scroll-behavior.html
+++ b/iron-auto-scroll-behavior.html
@@ -71,6 +71,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.autoScrollDisabled) {
         return;
       }
+      
+      // Convert key to index when needed
+      newValue = this._valueToIndex(newValue);
+
       // if it's the initial selection
       if (oldValue == undefined) {
         if (!this.noScrollForInitialSelection) {


### PR DESCRIPTION
When the iron-auto-scroll or iron-spy-scroll have an attr-for-selected attribute this method throws an exception.
